### PR TITLE
Add compliant and noncompliant examples of javascript/improper-certificate-validation@v1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# IntelliJ
+/.idea/
+*.iml
+
+node_modules

--- a/Test_PR.txt
+++ b/Test_PR.txt
@@ -1,1 +1,0 @@
-Hello World !!!

--- a/src/javascript/detectors/improper_certificate_validation/improper_certificate_validation.js
+++ b/src/javascript/detectors/improper_certificate_validation/improper_certificate_validation.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=improper-certificate-validation@v1.0 defects=1}
+var tls = require("tls")
+var fs = require("fs")
+
+function improperCertificateValidationNoncompliant() {
+    var options = {
+        host: 'encrypted.example.com',
+        // Noncompliant: rejectUnauthorized is set to 'false'.
+        rejectUnauthorized: false
+    }
+
+    tls.createServer(options, (req, res) => {
+        res.writeHead(200)
+        res.end()
+    }).listen(8000)
+}
+// {/fact}
+
+
+// {fact rule=improper-certificate-validation@v1.0 defects=0}
+var tls = require("tls")
+var fs = require("fs")
+
+function improperCertificateValidationCompliant() {
+    var options = {
+        // Compliant: certificate is provided.
+        key: fs.readFileSync('keys/client-key.pem'),
+        cert: fs.readFileSync('keys/client-cert.pem')
+    }
+
+    tls.createServer(options, (req, res) => {
+        res.writeHead(200)
+        res.end()
+    }).listen(8000)
+}
+// {/fact}

--- a/src/javascript/detectors/improper_certificate_validation/improper_certificate_validation.js
+++ b/src/javascript/detectors/improper_certificate_validation/improper_certificate_validation.js
@@ -28,6 +28,7 @@ var fs = require("fs")
 
 function improperCertificateValidationCompliant() {
     var options = {
+        host: 'encrypted.example.com',
         // Compliant: certificate is provided.
         key: fs.readFileSync('keys/client-key.pem'),
         cert: fs.readFileSync('keys/client-cert.pem')


### PR DESCRIPTION
*Description of changes:*
* Rules Added: javascript/improper-certificate-validation@v1.0
* Added new functions for compliant and non compliant examples
* Added .gitignore